### PR TITLE
Add 'by' prefix for owner in content type details

### DIFF
--- a/src/scripts/Components/TabPanel/Browse/Detail/ContentType.js
+++ b/src/scripts/Components/TabPanel/Browse/Detail/ContentType.js
@@ -271,7 +271,8 @@ class ContentType extends React.Component {
             >
               {this.props.library.title || this.props.library.machineName}
             </h2>
-            <div className="h5p-hub-owner">{this.props.library.owner}</div>
+            <span className='h5p-hub-by'>{Dictionary.get('by')}</span>
+            <span className="h5p-hub-owner">{this.props.library.owner}</span>
             <ReadMore
               text={this.props.library.description}
               maxLength={285}

--- a/src/scripts/Components/TabPanel/Browse/Detail/ContentType.scss
+++ b/src/scripts/Components/TabPanel/Browse/Detail/ContentType.scss
@@ -58,6 +58,11 @@ $color-back-button: #474f5a;
       h2 {
         margin-top: 0;
       }
+
+      .h5p-hub-by {
+        color: #666;
+        margin: 0 0.3em 0 0;
+      }
     }
 
     // larger then mobile

--- a/src/scripts/Components/TabPanel/Browse/List/ListItem/ListItem.js
+++ b/src/scripts/Components/TabPanel/Browse/List/ListItem/ListItem.js
@@ -33,7 +33,12 @@ const ListItem = ({contentType, apiVersion, tabindex, onSelect}) => {
       </div>
 
       <div className="h5p-hub-media-body">
-        <div className="h4 h5p-hub-media-heading">{title}</div>
+        <div className="h5p-hub-headline">
+          <span className="h5p-hub-title">{title}</span>
+          <span className='h5p-hub-by'>{Dictionary.get('by')}</span>
+          <span className="h5p-hub-owner">{contentType.owner}</span>
+        </div>
+
         { textIcons }
 
         {contentType.installed ? (

--- a/src/scripts/Components/TabPanel/Browse/List/ListItem/ListItem.scss
+++ b/src/scripts/Components/TabPanel/Browse/List/ListItem/ListItem.scss
@@ -29,10 +29,25 @@ $content-type-list-image-size: 100px;
     width: $content-type-list-image-size / 2;
   }
 
-  .h5p-hub-media-heading {
-    margin-top: 0;
+  .h5p-hub-headline {
     float: left;
-    margin-right: 0.5em;
+    font-size: $text-list-title;
+    margin: 0 0.5em $gutter / 2 0;
+
+    .h5p-hub-title {
+      font-weight: bold;
+      letter-spacing: -0.5px;
+    }
+
+    .h5p-hub-by {
+      font-size: 90%;
+      color: #666;
+      margin: 0 0.3em 0 0.6em;
+    }
+
+    .h5p-hub-owner {
+      font-size: 90%;
+    }
   }
 
   .h5p-hub-media-text-icon {


### PR DESCRIPTION
When merged in, will add 'by' prefix to the owner in the content type details view and it will add the by information behind the content type title for each content type list item.

It is often unclear to people that not all content types are created by the H5P core team/Joubel. This tiny extra piece of information is not much, buy may help to make it more clear who created the content type. I used the same design that was used for the Hub content list.

## Preview
### By prefix in details view
![By prefix in details view](https://h5p.org/sites/default/files/H5P-Hub-details-owner-information-new.png)

### Contributor information in list item
![Contributor information in list item](https://h5p.org/sites/default/files/H5P-Hub-overview-owner-information-new.png)