### PR TITLE
HFP-1982 Turn update available notification into link

### DIFF
--- a/src/scripts/Components/TabPanel/Browse/List/ListItem/ListItem.js
+++ b/src/scripts/Components/TabPanel/Browse/List/ListItem/ListItem.js
@@ -46,9 +46,14 @@ const ListItem = ({contentType, apiVersion, tabindex, onSelect}) => {
           </button>
         )}
 
-        <div className={'h5p-hub-content-type-update-info' + (updateAvailable ? '' : ' hidden')}>
-          {Dictionary.get('contentTypeUpdateAvailable')}
-        </div>
+        <button
+          type="button" className={'h5p-hub-content-type-update-info' + (updateAvailable ? '' : ' hidden')} tabIndex={tabindex}
+          onClick={(event) => {
+            handleSelect(event);
+          }}
+        >
+          {Dictionary.get('getUpdates')}
+        </button>
 
         <div className="h5p-hub-description">{contentType.summary || ''}</div>
       </div>

--- a/src/scripts/Components/TabPanel/Browse/List/ListItem/ListItem.scss
+++ b/src/scripts/Components/TabPanel/Browse/List/ListItem/ListItem.scss
@@ -54,17 +54,26 @@ $content-type-list-image-size: 100px;
   }
 
   .h5p-hub-content-type-update-info {
+    background-color: transparent;
     margin-right: 0;
-    color: $text-light;
+    color: $text-link;
     font-size: 0.8em;
     font-style: italic;
     float: left;
+    text-decoration: underline;
+
+    &:hover {
+      color: $text-link-hover;
+      cursor: pointer;
+    }
 
     &:before {
       @include icon($icon-update);
+      display: inline-block;
       font-style: normal;
       font-size: 0.8em;
       margin-right: 0.4em;
+      text-decoration: none;
     }
   }
 

--- a/src/scripts/utils/default-texts.js
+++ b/src/scripts/utils/default-texts.js
@@ -43,6 +43,7 @@ export default {
   readMore: 'Read more',
   readLess: 'Read less',  
   contentTypeUpdateAvailable: 'Update available',
+  getUpdates: 'Get updates',
   licenseDescription: 'Some of the features of this license are indicated below. Click the info icon above to read the original license text.',
   licenseModalTitle: 'License Details',
   licenseModalSubtitle: 'Select a license to view information about proper usage',

--- a/src/styles/base/_colors.scss
+++ b/src/styles/base/_colors.scss
@@ -20,5 +20,7 @@ $ac-warning: #ffcc33 !default;
 $ac-error: #c64750 !default;
 $text-dark: #1f2227 !default;
 $text-light: #697585 !default;
+$text-link: #1a93f4 !default;
+$text-link-hover: darken($text-link, 15%);
 
 $separator-color: #ececec !default;


### PR DESCRIPTION
When merged in, the "Update available" notification will be turned into a link-like button opening the details view (but not yet starting the update process) as described in [HFP-1982](https://h5ptechnology.atlassian.net/browse/HFP-1982).