### PR TITLE
Fix ignoring other library owner in license view

### DIFF
--- a/src/scripts/Components/TabPanel/Browse/Detail/ContentType.js
+++ b/src/scripts/Components/TabPanel/Browse/Detail/ContentType.js
@@ -135,7 +135,14 @@ class ContentType extends React.Component {
   handleShowLicenseDetails = () => {
 
     const licenseId = this.props.library.license.id;
-    let details = licenseCache[licenseId];
+    let details;
+
+    // Set current libraries owner information
+    if (licenseCache[licenseId]) {
+      details = licenseCache[licenseId]
+        .replace(':owner', this.props.library.owner)
+        .replace(':year', new Date().getFullYear());
+    }
 
     if (details) {
       // We already got it
@@ -150,7 +157,8 @@ class ContentType extends React.Component {
             details = Dictionary.get('licenseFetchDetailsFailed');
           }
           else {
-            details = licenseCache[licenseId] = response.description
+            licenseCache[licenseId] = response.description;
+            details = licenseCache[licenseId]
               .replace(':owner', this.props.library.owner)
               .replace(':year', new Date().getFullYear());
           }


### PR DESCRIPTION
Bug was reported at [https://h5p.org/node/1259230](https://h5p.org/node/1259230)

When showing a content type's license information, the license template is fetched, cached, and the placeholders for the owner and the year are overwritten immediately. When later on information for a different content type with the same license but a different owner is retrieved, still the old license text with the replaced placeholders is shown.

When merged in, the bug will be fixed by caching the license template but leaving the placeholders, so they can be replaced with the actual information when the license information is requested.