### PR TITLE
CH-54: Fix scss exports not working after css-loader package update

### DIFF
--- a/src/scripts/Components/TabPanel/Reuse/Detail/Content.js
+++ b/src/scripts/Components/TabPanel/Reuse/Detail/Content.js
@@ -7,7 +7,7 @@ import {
   licensesReducer,
   mapContentScreenShotsForImageSlider
 } from '../../../../utils/helpers';
-import variables from '../../../../../styles/base/_variables.scss';
+import variables from '../../../../../styles/_exports.module.scss';
 
 import Message from '../../../Message/Message';
 import Modal from '../../../Modal/Modal';

--- a/src/scripts/utils/paginationList.js
+++ b/src/scripts/utils/paginationList.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import variables from '../../styles/base/_variables.scss';
+import variables from '../../styles/_exports.module.scss';
 import Dictionary from './dictionary';
 
 export const pageNumToId = (num) => {

--- a/src/styles/_exports.module.scss
+++ b/src/styles/_exports.module.scss
@@ -1,0 +1,5 @@
+@import "base/variables";
+
+:export {
+  screenSmall: $screen-small;
+}

--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -23,7 +23,3 @@ $width-menu-item: 12em;
 $height-menuitem-underline: 3px;
 
 $box-shadow-blue: 0.06em 0 0.6em 0.1em #7bc1f9;
-
-:export {
-  screenSmall: $screen-small;
-}


### PR DESCRIPTION
CSS Modules or ICSS was previously default enabled in `css-loader`, this changed in version 4.0.0
Instead of force enabling CSS Modules or ICSS for all files handled by `css-loader`, the exported variables in SCSS was moved to a new file, `_exports.module.scss`, named to match the default `css-loader` config for enabling CSS Modules or ICSS