### PR TITLE
CH-140: Disable text inflation on mobile

### DIFF
--- a/src/scripts/Components/Hub.scss
+++ b/src/scripts/Components/Hub.scss
@@ -7,6 +7,9 @@
   padding-bottom: $gutter;
   position: relative;
   overflow: hidden;
+  -webkit-text-size-adjust: none;
+  text-size-adjust: none;
+
   .h5p-hub-panel {
     border: 1px solid $c1;
     background: #fff;


### PR DESCRIPTION
Disables the experimental feature that inflates blocks of text to a "minimum readable text size" on "small devices".
For further info see
- https://developer.mozilla.org/en-US/docs/Web/CSS/text-size-adjust
- https://w3c.github.io/csswg-drafts/css-size-adjust/