### PR TITLE
CH-142: Use new icon for checkbox mixed state

### DIFF
--- a/src/scripts/Components/Checkbox/Checkbox.scss
+++ b/src/scripts/Components/Checkbox/Checkbox.scss
@@ -76,7 +76,7 @@
       .h5p-hub-content {
         .h5p-hub-icon {
           &::before {
-            @include icon($icon-radio-selected); // TODO: Replace with correct icon when available
+            @include icon($icon-check-mixed);
             font-style: normal;
             font-weight: normal;
             font-size: 1em;

--- a/src/styles/base/_mixins.scss
+++ b/src/styles/base/_mixins.scss
@@ -20,6 +20,7 @@ $icon-remove: '\e904';
 $icon-filters: '\e90f';
 $icon-checkbox-check: '\e91c';
 $icon-check-empty: '\e91e';
+$icon-check-mixed: '\e907';
 $icon-arrow-thin: '\e906';
 $icon-colapse: '\e58e';
 


### PR DESCRIPTION
Requires updated version of the `h5p-hub` font, not part of this project